### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/DemoProject/DemoProject/Pods/CocoaSecurity/README.md
+++ b/DemoProject/DemoProject/Pods/CocoaSecurity/README.md
@@ -1,4 +1,4 @@
-#CocoaSecurity [![Build Status](https://secure.travis-ci.org/kelp404/CocoaSecurity.png?branch=master)](http://travis-ci.org/#!/kelp404/CocoaSecurity)
+# CocoaSecurity [![Build Status](https://secure.travis-ci.org/kelp404/CocoaSecurity.png?branch=master)](http://travis-ci.org/#!/kelp404/CocoaSecurity)
 
 Kelp https://twitter.com/kelp404/  
 [MIT License][mit]  
@@ -7,7 +7,7 @@ Kelp https://twitter.com/kelp404/
 
 CocoaSecurity include 4 classes, `CocoaSecurity`, `CocoaSecurityResult`, `CocoaSecurityEncoder` and `CocoaSecurityDecoder`.
 
-##CocoaSecurity
+## CocoaSecurity
 CocoaSecurity is core. It provides AES encrypt, AES decrypt, Hash(MD5, HmacMD5, SHA1~SHA512, HmacSHA1~HmacSHA512) messages.  
   
 **MD5:**
@@ -47,7 +47,7 @@ CocoaSecurityResult *aes256Decrypt = [CocoaSecurity aesDecryptWithBase64:@"WQYg5
 ```
 
 
-##CocoaSecurityResult
+## CocoaSecurityResult
 CocoaSecurityResult is the result class of CocoaSecurity. It provides convert result data to NSData, NSString, HEX string, Base64 string.
 
 ```objective-c
@@ -59,7 +59,7 @@ CocoaSecurityResult is the result class of CocoaSecurity. It provides convert re
 ```
 
 
-##CocoaSecurityEncoder
+## CocoaSecurityEncoder
 CocoaSecurityEncoder provides convert NSData to HEX string, Base64 string.
 
 ```objective-c
@@ -75,7 +75,7 @@ NSString *str2 = [encoder base64:[@"kelp" dataUsingEncoding:NSUTF8StringEncoding
 // str2 = 'a2VscA=='
 ```
 
-##CocoaSecurityDecoder
+## CocoaSecurityDecoder
 CocoaSecurityEncoder provides convert HEX string or Base64 string to NSData.
 
 ```objective-c
@@ -92,7 +92,7 @@ NSData *data2 = [decoder base64:@"zT1PS64MnXIUDCUiy13RRg=="];
 ```
 
 
-##Installation
+## Installation
 1. **git:**
 ```
 $ git clone git://github.com/kelp404/CocoaSecurity.git

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ NSUserDefaults+SevenSecurityLayers.h
 * Using strong AES 356-bit encryption
 
 -------------------------------------
-####Benefit: 
+#### Benefit: 
 ##### * Secure user data just by one line of code.
 ##### * Support obfuscating your key in binary source
 ##### * Able to save data without encryption
@@ -59,7 +59,7 @@ NSString * yourString = [pref stringForKey:@"KindOfEncrytion"];
 ...
 
 ```
-###Advanced usage
+### Advanced usage
 
 * **v1.2.0** available
 
@@ -110,18 +110,18 @@ Email: haikieu2907@gmail.com
 
 <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=SLWW2XYDATUYS" target="_blank"><img src="https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif" alt="Make donation for Hai Kieu's github"/></a>
 
-###Thanks to 
+### Thanks to 
 
  * https://github.com/nielsmouthaan/SecureNSUserDefaults
  * https://github.com/UrbanApps/UAObfuscatedString
 
 ### MIT License
 
-###Dependencies
+### Dependencies
 
  * CocoaSecurity 1.2.4 (https://github.com/kelp404/CocoaSecurity)
 
-###Dependencies Installation
+### Dependencies Installation
 1. **git:**
 ```
 $ git clone git://github.com/kelp404/CocoaSecurity.git


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
